### PR TITLE
Fixed an issue with error handling in task waiter

### DIFF
--- a/src/features/serverTasks/serverTaskWaiter.test.ts
+++ b/src/features/serverTasks/serverTaskWaiter.test.ts
@@ -1,0 +1,23 @@
+import { Client } from "../../client";
+import { processConfiguration } from "../../clientConfiguration.test";
+import { ServerTaskDetails } from "./serverTaskDetails";
+import { ServerTaskWaiter } from "./serverTaskWaiter";
+
+describe("push build information", () => {
+    jest.setTimeout(100000);
+
+    test("wait for non-existent task exits correctly", async () => {
+        const client = await Client.create(processConfiguration());
+        const serverTaskWaiter = new ServerTaskWaiter(client, "Default");
+
+        const startTime = new Date();
+
+        await expect(() => {
+            return serverTaskWaiter.waitForServerTaskToComplete("ServerTasks-99999", 1000, 10000);
+        }).rejects.toThrow();
+
+        const endTime = new Date();
+        const timeDiff = endTime.getTime() - startTime.getTime();
+        expect(timeDiff).toBeLessThan(6000);
+    });
+});

--- a/src/features/serverTasks/serverTaskWaiter.ts
+++ b/src/features/serverTasks/serverTaskWaiter.ts
@@ -44,21 +44,26 @@ export class ServerTaskWaiter {
         }, timeout);
 
         while (!stop) {
-            if (pollingCallback) {
-                const taskDetails = await spaceServerTaskRepository.getDetails(serverTaskId);
-                pollingCallback(taskDetails);
+            try {
+                if (pollingCallback) {
+                    const taskDetails = await spaceServerTaskRepository.getDetails(serverTaskId);
+                    pollingCallback(taskDetails);
 
-                if (taskDetails.Task.IsCompleted) {
-                    clearTimeout(t);
-                    return taskDetails.Task;
-                }
-            } else {
-                const task = await spaceServerTaskRepository.getById(serverTaskId);
+                    if (taskDetails.Task.IsCompleted) {
+                        clearTimeout(t);
+                        return taskDetails.Task;
+                    }
+                } else {
+                    const task = await spaceServerTaskRepository.getById(serverTaskId);
 
-                if (task.IsCompleted) {
-                    clearTimeout(t);
-                    return task;
+                    if (task.IsCompleted) {
+                        clearTimeout(t);
+                        return task;
+                    }
                 }
+            } catch (e) {
+                clearTimeout(t);
+                throw e;
             }
 
             await sleep(statusCheckSleepCycle);

--- a/src/features/serverTasks/serverTaskWaiter.ts
+++ b/src/features/serverTasks/serverTaskWaiter.ts
@@ -50,20 +50,17 @@ export class ServerTaskWaiter {
                     pollingCallback(taskDetails);
 
                     if (taskDetails.Task.IsCompleted) {
-                        clearTimeout(t);
                         return taskDetails.Task;
                     }
                 } else {
                     const task = await spaceServerTaskRepository.getById(serverTaskId);
 
                     if (task.IsCompleted) {
-                        clearTimeout(t);
                         return task;
                     }
                 }
-            } catch (e) {
+            } finally {
                 clearTimeout(t);
-                throw e;
             }
 
             await sleep(statusCheckSleepCycle);


### PR DESCRIPTION
Background:
During additional testing of the `await-task-action` it was found that if an invalid server task id was past to the `ServerTaskWaiter` the action would detect the error rapidly but not complete until the timeout had expired.

Upon investigation this came back to the `ServerTaskWaiter` needing to catch errors and cleanup the timer promise before rethrowing.