### PR TITLE
Fixed a bug with nested directory handling

### DIFF
--- a/src/features/packages/pack/TestNuGetPackageWithSpec.nuspec
+++ b/src/features/packages/pack/TestNuGetPackageWithSpec.nuspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>TestNuGetPackageWithSpec</id>
+        <version>1.0.0</version>
+        <description>This is a test NuGet Package</description>
+        <authors>Test AuthorA,Test AuthorB</authors>
+    </metadata>
+</package>

--- a/src/features/packages/pack/nugetPackageBuilder.test.ts
+++ b/src/features/packages/pack/nugetPackageBuilder.test.ts
@@ -90,7 +90,7 @@ describe("Can create a NuGet packages", () => {
         fs.writeFileSync(path.join(tmpFolder, "NuGetPackagingTest.txt"), "Some test content to add to the zip archive");
         const packageBuilder = new NuGetPackageBuilder();
         await packageBuilder.pack({
-            packageId: "TestNuGetPackage",
+            packageId: "TestNuGetPackageRel",
             version: "1.0.1",
             basePath: tmpFolder,
             inputFilePatterns: ["NuGetPackagingTest.txt"],
@@ -99,7 +99,7 @@ describe("Can create a NuGet packages", () => {
             logger,
         });
 
-        const expectedPackageFile = path.join("RelativeFolderTest", "TestNuGetPackage.1.0.1.nupkg");
+        const expectedPackageFile = path.join("RelativeFolderTest", "TestNuGetPackageRel.1.0.1.nupkg");
 
         expect(fs.existsSync(expectedPackageFile)).toBe(true);
         const zip = new AdmZip(expectedPackageFile);

--- a/src/features/packages/pack/nugetPackageBuilder.test.ts
+++ b/src/features/packages/pack/nugetPackageBuilder.test.ts
@@ -19,7 +19,8 @@ describe("Can create a NuGet packages", () => {
         await packageBuilder.pack({
             packageId: "TestNuGetPackage",
             version: "1.0.1",
-            inputFilePatterns: [path.join(tmpFolder, "NuGetPackagingTest.txt")],
+            basePath: tmpFolder,
+            inputFilePatterns: ["NuGetPackagingTest.txt"],
             outputFolder: tmpFolder,
             overwrite: true,
             logger,
@@ -41,7 +42,8 @@ describe("Can create a NuGet packages", () => {
         await packageBuilder.pack({
             packageId: "TestNuGetPackageA",
             version: "1.1.1",
-            inputFilePatterns: ["src/features/packages/pack/*.ts"],
+            basePath: "src/features/packages/pack",
+            inputFilePatterns: ["*.ts"],
             outputFolder: tmpFolder,
             overwrite: true,
             logger,
@@ -63,7 +65,8 @@ describe("Can create a NuGet packages", () => {
         await packageBuilder.pack({
             packageId: "TestNuGetPackageWithSpec",
             version: "1.0.0",
-            inputFilePatterns: ["src/features/packages/pack/*.ts"],
+            basePath: "src/features/packages/pack",
+            inputFilePatterns: ["*.ts"],
             outputFolder: tmpFolder,
             overwrite: true,
             nuspecArgs: {
@@ -89,7 +92,8 @@ describe("Can create a NuGet packages", () => {
         await packageBuilder.pack({
             packageId: "TestNuGetPackage",
             version: "1.0.1",
-            inputFilePatterns: [path.join(tmpFolder, "NuGetPackagingTest.txt")],
+            basePath: tmpFolder,
+            inputFilePatterns: ["NuGetPackagingTest.txt"],
             outputFolder: "RelativeFolderTest",
             overwrite: true,
             logger,

--- a/src/features/packages/pack/nugetPackageBuilder.ts
+++ b/src/features/packages/pack/nugetPackageBuilder.ts
@@ -41,7 +41,7 @@ export class NuGetPackageBuilder {
             inputFilePatterns.push(nuspecFile);
         }
 
-        await doZip(inputFilePatterns, args.outputFolder, archiveFilename, args.logger, 8, args.overwrite);
+        await doZip(args.basePath, inputFilePatterns, args.outputFolder, archiveFilename, args.logger, 8, args.overwrite);
 
         return archiveFilename;
     }

--- a/src/features/packages/pack/nugetPackageBuilder.ts
+++ b/src/features/packages/pack/nugetPackageBuilder.ts
@@ -17,11 +17,11 @@ type NuGetPackArgs = {
 export class NuGetPackageBuilder {
     async pack(args: NuGetPackArgs): Promise<string> {
         const archiveFilename = `${args.packageId}.${args.version}.nupkg`;
-        const tmpFolder = os.tmpdir();
         const inputFilePatterns = args.inputFilePatterns;
 
         if (args.nuspecArgs) {
-            const nuspecFile = path.join(tmpFolder, `${args.packageId}.nuspec`);
+            const nuspecFilename = `${args.packageId}.nuspec`;
+            const nuspecFile = path.join(args.basePath, nuspecFilename);
             fs.writeFileSync(nuspecFile, '<?xml version="1.0" encoding="utf-8"?>\n');
             fs.appendFileSync(nuspecFile, '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n');
             fs.appendFileSync(nuspecFile, "    <metadata>\n");
@@ -38,7 +38,7 @@ export class NuGetPackageBuilder {
             fs.appendFileSync(nuspecFile, "</package>\n");
 
             // include the nuspec into the package
-            inputFilePatterns.push(nuspecFile);
+            inputFilePatterns.push(nuspecFilename);
         }
 
         await doZip(args.basePath, inputFilePatterns, args.outputFolder, archiveFilename, args.logger, 8, args.overwrite);

--- a/src/features/packages/pack/packArgs.ts
+++ b/src/features/packages/pack/packArgs.ts
@@ -3,6 +3,7 @@ import { Logger } from "../../../logger";
 export type PackArgs = {
     packageId: string;
     version: string;
+    basePath: string;
     inputFilePatterns: string[];
     outputFolder: string;
     overwrite?: boolean;

--- a/src/features/packages/pack/zipPackageBuilder.test.ts
+++ b/src/features/packages/pack/zipPackageBuilder.test.ts
@@ -36,7 +36,6 @@ describe("Can create a Zip packages", () => {
     test("Can create with wildcarded files", async () => {
         const tmpFolder = os.tmpdir();
 
-        fs.writeFileSync(path.join(tmpFolder, "ZipPackagingTest1.txt"), "Some test content to add to the zip archive AAA");
         const zipPackageBuilder = new ZipPackageBuilder();
         await zipPackageBuilder.pack({
             packageId: "TestPackageA",
@@ -52,6 +51,27 @@ describe("Can create a Zip packages", () => {
         expect(fs.existsSync(expectedPackageFile)).toBe(true);
         const zip = new AdmZip(expectedPackageFile);
         const entry = zip.getEntry("zipPackageBuilder.ts");
+        expect(entry).not.toBeNull();
+    });
+
+    test("Can create with wildcarded directories", async () => {
+        const tmpFolder = os.tmpdir();
+
+        const zipPackageBuilder = new ZipPackageBuilder();
+        await zipPackageBuilder.pack({
+            packageId: "TestPackageWild",
+            version: "1.1.1",
+            inputFilePatterns: ["src/features/**/*"],
+            outputFolder: tmpFolder,
+            overwrite: true,
+            logger,
+        });
+
+        const expectedPackageFile = path.join(tmpFolder, `TestPackageWild.1.1.1.zip`);
+
+        expect(fs.existsSync(expectedPackageFile)).toBe(true);
+        const zip = new AdmZip(expectedPackageFile);
+        const entry = zip.getEntry("src/features/index.ts");
         expect(entry).not.toBeNull();
     });
 });

--- a/src/features/packages/pack/zipPackageBuilder.test.ts
+++ b/src/features/packages/pack/zipPackageBuilder.test.ts
@@ -19,7 +19,8 @@ describe("Can create a Zip packages", () => {
         await zipPackageBuilder.pack({
             packageId: "TestPackage",
             version: "1.0.1",
-            inputFilePatterns: [path.join(tmpFolder, "ZipPackagingTest.txt")],
+            basePath: tmpFolder,
+            inputFilePatterns: ["ZipPackagingTest.txt"],
             outputFolder: tmpFolder,
             overwrite: true,
             logger,
@@ -40,7 +41,8 @@ describe("Can create a Zip packages", () => {
         await zipPackageBuilder.pack({
             packageId: "TestPackageA",
             version: "1.1.1",
-            inputFilePatterns: ["src/features/packages/pack/*.ts"],
+            basePath: "src/features/packages/pack",
+            inputFilePatterns: ["*.ts"],
             outputFolder: tmpFolder,
             overwrite: true,
             logger,
@@ -50,18 +52,19 @@ describe("Can create a Zip packages", () => {
 
         expect(fs.existsSync(expectedPackageFile)).toBe(true);
         const zip = new AdmZip(expectedPackageFile);
-        const entry = zip.getEntry("zipPackageBuilder.ts");
+        const entry = zip.getEntry("zipPackageBuilder.test.ts");
         expect(entry).not.toBeNull();
     });
 
-    test("Can create with wildcarded directories", async () => {
+    test("Can create with multiples and wildcarded directories", async () => {
         const tmpFolder = os.tmpdir();
 
         const zipPackageBuilder = new ZipPackageBuilder();
         await zipPackageBuilder.pack({
             packageId: "TestPackageWild",
             version: "1.1.1",
-            inputFilePatterns: ["src/features/**/*"],
+            basePath: "src",
+            inputFilePatterns: ["features/basicRepository.ts", "features/packages/**/*", "features/projects/**/*"],
             outputFolder: tmpFolder,
             overwrite: true,
             logger,
@@ -71,7 +74,11 @@ describe("Can create a Zip packages", () => {
 
         expect(fs.existsSync(expectedPackageFile)).toBe(true);
         const zip = new AdmZip(expectedPackageFile);
-        const entry = zip.getEntry("src/features/index.ts");
+        let entry = zip.getEntry("features/basicRepository.ts");
+        expect(entry).not.toBeNull();
+        entry = zip.getEntry("features/packages/pack/zipPackageBuilder.test.ts");
+        expect(entry).not.toBeNull();
+        entry = zip.getEntry("features/projects/index.ts");
         expect(entry).not.toBeNull();
     });
 });

--- a/src/features/packages/pack/zipPackageBuilder.test.ts
+++ b/src/features/packages/pack/zipPackageBuilder.test.ts
@@ -81,4 +81,30 @@ describe("Can create a Zip packages", () => {
         entry = zip.getEntry("features/projects/index.ts");
         expect(entry).not.toBeNull();
     });
+
+    test("Can create with '.' as the basePath", async () => {
+        const tmpFolder = os.tmpdir();
+
+        const zipPackageBuilder = new ZipPackageBuilder();
+        await zipPackageBuilder.pack({
+            packageId: "TestPackageDot",
+            version: "1.1.1",
+            basePath: ".",
+            inputFilePatterns: ["src/features/basicRepository.ts", "src/features/packages/**/*", "src/features/projects/**/*"],
+            outputFolder: tmpFolder,
+            overwrite: true,
+            logger,
+        });
+
+        const expectedPackageFile = path.join(tmpFolder, `TestPackageDot.1.1.1.zip`);
+
+        expect(fs.existsSync(expectedPackageFile)).toBe(true);
+        const zip = new AdmZip(expectedPackageFile);
+        let entry = zip.getEntry("src/features/basicRepository.ts");
+        expect(entry).not.toBeNull();
+        entry = zip.getEntry("src/features/packages/pack/zipPackageBuilder.test.ts");
+        expect(entry).not.toBeNull();
+        entry = zip.getEntry("src/features/projects/index.ts");
+        expect(entry).not.toBeNull();
+    });
 });

--- a/src/features/packages/pack/zipPackageBuilder.ts
+++ b/src/features/packages/pack/zipPackageBuilder.ts
@@ -8,7 +8,7 @@ type ZipPackArgs = {
 export class ZipPackageBuilder {
     async pack(args: ZipPackArgs): Promise<string> {
         const archiveFilename = `${args.packageId}.${args.version}.zip`;
-        await doZip(args.inputFilePatterns, args.outputFolder, archiveFilename, args.logger, args.compressionLevel, args.overwrite);
+        await doZip(args.basePath, args.inputFilePatterns, args.outputFolder, archiveFilename, args.logger, args.compressionLevel, args.overwrite);
         return archiveFilename;
     }
 }

--- a/src/features/packages/pack/zipUtils.ts
+++ b/src/features/packages/pack/zipUtils.ts
@@ -1,4 +1,5 @@
 import AdmZip from "adm-zip";
+import fs from "fs";
 import { glob } from "glob";
 import path from "path";
 import { promisify } from "util";
@@ -23,7 +24,11 @@ export async function doZip(
     for (const file of files) {
         logger.debug?.(`Adding file: ${file}...`);
 
-        zip.addLocalFile(file);
+        if (fs.lstatSync(file).isDirectory()) {
+            zip.addFile(`${file}/`, new Buffer([0x00]));
+        } else {
+            zip.addLocalFile(file, path.dirname(file));
+        }
     }
 
     if (compressionLevel) {

--- a/src/features/packages/pack/zipUtils.ts
+++ b/src/features/packages/pack/zipUtils.ts
@@ -40,7 +40,7 @@ export async function doZip(
         logger.debug?.(`Adding file: ${file}...`);
 
         if (fs.lstatSync(file).isDirectory()) {
-            zip.addFile(`${file}/`, new Buffer([0x00]));
+            zip.addFile(`${file}/`, Buffer.from([0x00]));
         } else {
             const dirName = path.dirname(file);
             zip.addLocalFile(file, dirName === "." ? "" : dirName);
@@ -54,7 +54,7 @@ export async function doZip(
 
     process.chdir(initialWorkingDirectory);
 
-    await zip.writeZipPromise(archivePath, { overwrite: overwrite });
+    await zip.writeZipPromise(archivePath, { overwrite: overwrite || true });
 }
 
 const setCompressionLevel = (zip: AdmZip, level: number): void => {


### PR DESCRIPTION
When nested directories were specified as input the Zipping code was not handling the directories correctly and would throw an error.

This PR fixes the handling to correctly create the right folders within the Zip.

Related to this, the initial implementation would flatten the directories into the root of the archive. This has also been corrected. To help with package of files for Octopus a basePath has been introduced. So you point to the basePath and then provide input file globs relative to that location.