### PR TITLE
Fixed a bug with the prompted variables structure

### DIFF
--- a/src/features/projects/createExecutionBaseV1.ts
+++ b/src/features/projects/createExecutionBaseV1.ts
@@ -9,5 +9,5 @@ export interface CreateExecutionBaseV1 extends SpaceScopedOperation {
     UseGuidedFailure?: boolean;
     RunAt?: Date | undefined;
     NoRunAfter?: Date | undefined;
-    Variables?: Map<string, string>;
+    Variables?: { [name: string]: string };
 }

--- a/src/features/projects/createExecutionBaseV1.ts
+++ b/src/features/projects/createExecutionBaseV1.ts
@@ -9,5 +9,9 @@ export interface CreateExecutionBaseV1 extends SpaceScopedOperation {
     UseGuidedFailure?: boolean;
     RunAt?: Date | undefined;
     NoRunAfter?: Date | undefined;
-    Variables?: { [name: string]: string };
+    Variables?: PromptedVariableValues;
+}
+
+export interface PromptedVariableValues {
+    [name: string]: string;
 }


### PR DESCRIPTION
In writing the TypeScript client a `Map<string,string>` was used to represent the prompted variables key/value pairs, because that nicely aligned with the dictionary structure Octopus uses internally for this data.

Unfortunately it doesn't serialize as expected on the wire.

This PR changes to use a new interface type, `PromptedVariableValues`, which still behaves like a dictionary and key/value pairs in TypeScript and serializes as expected.

Fixes #139