### PR TITLE
Modified the ServerTaskWaiter implementation

### DIFF
--- a/src/features/projects/releases/deployments/deploymentRepository.test.ts
+++ b/src/features/projects/releases/deployments/deploymentRepository.test.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "crypto";
 import { Client } from "../../../../client";
 import { processConfiguration } from "../../../../clientConfiguration.test";
 import { DeploymentEnvironment, EnvironmentRepository } from "../../../../features/deploymentEnvironments";
-import { ServerTaskDetails, ServerTaskWaiter } from "../../../../features/serverTasks";
+import { ServerTask, ServerTaskWaiter } from "../../../../features/serverTasks";
 import { ReleaseRepository, CreateReleaseCommandV1 } from "../../../projects/releases";
 import { CreateDeploymentUntenantedCommandV1 } from "./createDeploymentUntenantedCommandV1";
 import { DeploymentRepository } from "./deploymentRepository";
@@ -120,10 +120,8 @@ describe("deploy a release", () => {
         const taskIds = response.DeploymentServerTasks.map((x) => x.ServerTaskId);
         const e = new ServerTaskWaiter(client, space.Name);
 
-        await e.waitForServerTasksToComplete(taskIds, 1000, 600000, (serverTaskDetails: ServerTaskDetails): void => {
-            console.log(
-                `Waiting for task ${serverTaskDetails.Task.Id}. Current status: ${serverTaskDetails.Task.State}, completed: ${serverTaskDetails.Progress.ProgressPercentage}%`
-            );
+        await e.waitForServerTasksToComplete(taskIds, 1000, 600000, (serverTask: ServerTask): void => {
+            console.log(`Waiting for task ${serverTask.Id}. Current status: ${serverTask.State}`);
         });
     });
 

--- a/src/features/serverTasks/serverTaskWaiter.test.ts
+++ b/src/features/serverTasks/serverTaskWaiter.test.ts
@@ -14,7 +14,7 @@ describe("push build information", () => {
 
         await expect(() => {
             return serverTaskWaiter.waitForServerTaskToComplete("ServerTasks-99999", 1000, 10000);
-        }).rejects.toThrow();
+        }).rejects.toThrow("Unknown task Id(s) ServerTasks-99999");
 
         const endTime = new Date();
         const timeDiff = endTime.getTime() - startTime.getTime();

--- a/src/features/serverTasks/serverTaskWaiter.ts
+++ b/src/features/serverTasks/serverTaskWaiter.ts
@@ -34,6 +34,13 @@ export class ServerTaskWaiter {
         timeout: number,
         pollingCallback?: (serverTask: ServerTask) => void
     ): Promise<ServerTask[]> {
+        // short circuit if no ids are passed. Sending an empty array to server here
+        // doesn't do what you may expect. To server, no ids == return every task the user
+        // has permission to see
+        if (serverTaskIds.length === 0) {
+            return [];
+        }
+
         const sleep = async (ms: number) => new Promise((r) => setTimeout(r, ms));
 
         let stop = false;


### PR DESCRIPTION
The original implementation was based on older logic, from the C# CLI and portal behaviours. It was very chatting and potentially quite inefficient though. This PR modifies the external contract for it just slightly and re-implements the internal behaviour to use less API calls.