### PR TITLE
Fixed Execution API version check

### DIFF
--- a/src/features/projects/releases/deployments/deploymentRepository.ts
+++ b/src/features/projects/releases/deployments/deploymentRepository.ts
@@ -56,12 +56,12 @@ export class DeploymentRepository {
     async create(command: CreateDeploymentUntenantedCommandV1): Promise<CreateDeploymentUntenantedResponseV1> {
         const serverInformation = await this.client.getServerInformation();
         const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5085")) {
+        if (serverVersion < new SemVer("2022.3.5512")) {
             this.client.error?.(
-                "The Octopus instance doesn't support deploying releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support deploying releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
             throw new Error(
-                "The Octopus instance doesn't support deploying releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support deploying releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
         }
 
@@ -95,12 +95,12 @@ export class DeploymentRepository {
     async createTenanted(command: CreateDeploymentTenantedCommandV1): Promise<CreateDeploymentTenantedResponseV1> {
         const serverInformation = await this.client.getServerInformation();
         const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5085")) {
+        if (serverVersion < new SemVer("2022.3.5512")) {
             this.client.error?.(
-                "The Octopus instance doesn't support deploying tenanted releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support deploying tenanted releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
             throw new Error(
-                "The Octopus instance doesn't support deploying tenanted releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support deploying tenanted releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
         }
 

--- a/src/features/projects/releases/releaseRepository.ts
+++ b/src/features/projects/releases/releaseRepository.ts
@@ -1,7 +1,8 @@
 import type { Client } from "../../../client";
-import { checkForCapability, spaceScopedRoutePrefix } from "../../..";
+import { spaceScopedRoutePrefix } from "../../..";
 import { CreateReleaseCommandV1 } from "./createReleaseCommandV1";
 import { CreateReleaseResponseV1 } from "./createReleaseResponseV1";
+import { SemVer } from "semver";
 
 export class ReleaseRepository {
     private client: Client;
@@ -13,10 +14,15 @@ export class ReleaseRepository {
     }
 
     async create(command: CreateReleaseCommandV1): Promise<CreateReleaseResponseV1> {
-        const capabilityError = await checkForCapability(this.client, "CreateReleaseCommandV1", "2022.3");
-        if (capabilityError) {
-            this.client.error?.(capabilityError);
-            throw new Error(capabilityError);
+        const serverInformation = await this.client.getServerInformation();
+        const serverVersion = new SemVer(serverInformation.version);
+        if (serverVersion < new SemVer("2022.3.5085")) {
+            this.client.error?.(
+                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+            );
+            throw new Error(
+                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+            );
         }
 
         this.client.debug(`Creating a release...`);

--- a/src/features/projects/releases/releaseRepository.ts
+++ b/src/features/projects/releases/releaseRepository.ts
@@ -16,12 +16,12 @@ export class ReleaseRepository {
     async create(command: CreateReleaseCommandV1): Promise<CreateReleaseResponseV1> {
         const serverInformation = await this.client.getServerInformation();
         const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5085")) {
+        if (serverVersion < new SemVer("2022.3.5512")) {
             this.client.error?.(
-                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
             throw new Error(
-                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
         }
 

--- a/src/features/projects/runbooks/runs/runbookRunRepository.ts
+++ b/src/features/projects/runbooks/runs/runbookRunRepository.ts
@@ -54,12 +54,12 @@ export class RunbookRunRepository {
     async create(command: CreateRunbookRunCommandV1): Promise<CreateRunbookRunResponseV1> {
         const serverInformation = await this.client.getServerInformation();
         const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5085")) {
+        if (serverVersion < new SemVer("2022.3.5512")) {
             this.client.error?.(
-                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
             throw new Error(
-                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
         }
 

--- a/src/features/projects/runbooks/runs/runbookRunRepository.ts
+++ b/src/features/projects/runbooks/runs/runbookRunRepository.ts
@@ -5,7 +5,7 @@ import { spaceScopedRoutePrefix } from "../../../../spaceScopedRoutePrefix";
 import { ListArgs } from "../../../basicRepository";
 import { ResourceCollection } from "../../../../resourceCollection";
 import { CreateRunbookRunCommandV1, CreateRunbookRunResponseV1 } from "./createRunbookRunCommandV1";
-import { checkForCapability } from "../../../capabilities";
+import { SemVer } from "semver";
 
 // WARNING: we've had to do this to cover a mistake in Octopus' API. The API has been corrected to return PascalCase, but was returning camelCase
 // for a number of versions, so we'll deserialize both and use whichever actually has a value
@@ -52,10 +52,15 @@ export class RunbookRunRepository {
     }
 
     async create(command: CreateRunbookRunCommandV1): Promise<CreateRunbookRunResponseV1> {
-        const capabilityError = await checkForCapability(this.client, "CreateRunbookRunCommandV1", "2022.3");
-        if (capabilityError) {
-            this.client.error?.(capabilityError);
-            throw new Error(capabilityError);
+        const serverInformation = await this.client.getServerInformation();
+        const serverVersion = new SemVer(serverInformation.version);
+        if (serverVersion < new SemVer("2022.3.5085")) {
+            this.client.error?.(
+                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+            );
+            throw new Error(
+                "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5085 in order to access this API."
+            );
         }
 
         this.client.debug(`Running a runbook...`);


### PR DESCRIPTION
This PR changes the checks for the availability of the Executions API. The Capabilities API would normally be able to cover this, but a delay in its own original release means there's a timing gap that it can't cover, so we're reverting to doing a SemVer check against the Octopus server version.

The version number being checked is the first publicly available version I could determine that was after the Execution API feature set was released.