### PR TITLE
fix: properly compare versions

### DIFF
--- a/src/features/projects/releases/deployments/deploymentRepository.ts
+++ b/src/features/projects/releases/deployments/deploymentRepository.ts
@@ -8,7 +8,7 @@ import {
     CreateDeploymentUntenantedCommandV1,
     CreateDeploymentUntenantedResponseV1,
 } from ".";
-import { SemVer } from "semver";
+import { lt } from "semver";
 
 // WARNING: we've had to do this to cover a mistake in Octopus' API. The API has been corrected to return PascalCase, but was returning camelCase
 // for a number of versions, so we'll deserialize both and use whichever actually has a value
@@ -55,8 +55,7 @@ export class DeploymentRepository {
 
     async create(command: CreateDeploymentUntenantedCommandV1): Promise<CreateDeploymentUntenantedResponseV1> {
         const serverInformation = await this.client.getServerInformation();
-        const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5512")) {
+        if (lt(serverInformation.version, "2022.3.5512")) {
             this.client.error?.(
                 "The Octopus instance doesn't support deploying releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );
@@ -94,8 +93,7 @@ export class DeploymentRepository {
 
     async createTenanted(command: CreateDeploymentTenantedCommandV1): Promise<CreateDeploymentTenantedResponseV1> {
         const serverInformation = await this.client.getServerInformation();
-        const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5512")) {
+        if (lt(serverInformation.version, "2022.3.5512")) {
             this.client.error?.(
                 "The Octopus instance doesn't support deploying tenanted releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );

--- a/src/features/projects/releases/releaseRepository.ts
+++ b/src/features/projects/releases/releaseRepository.ts
@@ -2,7 +2,7 @@ import type { Client } from "../../../client";
 import { spaceScopedRoutePrefix } from "../../..";
 import { CreateReleaseCommandV1 } from "./createReleaseCommandV1";
 import { CreateReleaseResponseV1 } from "./createReleaseResponseV1";
-import { SemVer } from "semver";
+import { lt } from "semver";
 
 export class ReleaseRepository {
     private client: Client;
@@ -15,8 +15,7 @@ export class ReleaseRepository {
 
     async create(command: CreateReleaseCommandV1): Promise<CreateReleaseResponseV1> {
         const serverInformation = await this.client.getServerInformation();
-        const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5512")) {
+        if (lt(serverInformation.version, "2022.3.5512")) {
             this.client.error?.(
                 "The Octopus instance doesn't support creating releases using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );

--- a/src/features/projects/runbooks/runs/runbookRunRepository.ts
+++ b/src/features/projects/runbooks/runs/runbookRunRepository.ts
@@ -5,7 +5,7 @@ import { spaceScopedRoutePrefix } from "../../../../spaceScopedRoutePrefix";
 import { ListArgs } from "../../../basicRepository";
 import { ResourceCollection } from "../../../../resourceCollection";
 import { CreateRunbookRunCommandV1, CreateRunbookRunResponseV1 } from "./createRunbookRunCommandV1";
-import { SemVer } from "semver";
+import { lt } from "semver";
 
 // WARNING: we've had to do this to cover a mistake in Octopus' API. The API has been corrected to return PascalCase, but was returning camelCase
 // for a number of versions, so we'll deserialize both and use whichever actually has a value
@@ -53,8 +53,7 @@ export class RunbookRunRepository {
 
     async create(command: CreateRunbookRunCommandV1): Promise<CreateRunbookRunResponseV1> {
         const serverInformation = await this.client.getServerInformation();
-        const serverVersion = new SemVer(serverInformation.version);
-        if (serverVersion < new SemVer("2022.3.5512")) {
+        if (lt(serverInformation.version, "2022.3.5512")) {
             this.client.error?.(
                 "The Octopus instance doesn't support running runbooks using the Executions API, it will need to be upgraded to at least 2022.3.5512 in order to access this API."
             );


### PR DESCRIPTION
Uses `semver`'s `lt()` function to compare version strings, rather than `<`.

Fixes #157.