### PR TITLE
fix: tenant get variables

### DIFF
--- a/src/features/tenants/tenantRepository.ts
+++ b/src/features/tenants/tenantRepository.ts
@@ -35,7 +35,7 @@ export class TenantRepository extends SpaceScopedBasicRepository<Tenant, NewTena
     }
 
     setVariables(tenant: Tenant, variables: any): Promise<TenantVariable> {
-        return this.client.doUpdate(`${spaceScopedRoutePrefix}/tenants/${tenant.Id}/variables`, variables, {
+        return this.client.doUpdate(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, variables, {
             spaceName: this.spaceName,
             id: tenant.Id,
         });

--- a/src/features/tenants/tenantRepository.ts
+++ b/src/features/tenants/tenantRepository.ts
@@ -24,7 +24,7 @@ export class TenantRepository extends SpaceScopedBasicRepository<Tenant, NewTena
     }
 
     getVariables(tenant: Tenant): Promise<TenantVariable> {
-        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, tenant);
+        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, { id: tenant.Id });
     }
 
     setVariables(tenant: Tenant, variables: any): Promise<TenantVariable> {

--- a/src/features/tenants/tenantRepository.ts
+++ b/src/features/tenants/tenantRepository.ts
@@ -20,19 +20,30 @@ export class TenantRepository extends SpaceScopedBasicRepository<Tenant, NewTena
     }
 
     tagTest(tenantIds: string[], tags: string[]): Promise<TagTestResult> {
-        return this.client.request(`${spaceScopedRoutePrefix}/tenants/tag-test{?tenantIds,tags}`, { tenantIds, tags });
+        return this.client.request(`${spaceScopedRoutePrefix}/tenants/tag-test{?tenantIds,tags}`, {
+            spaceName: this.spaceName,
+            tenantIds,
+            tags,
+        });
     }
 
     getVariables(tenant: Tenant): Promise<TenantVariable> {
-        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, { id: tenant.Id });
+        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, {
+            spaceName: this.spaceName,
+            id: tenant.Id,
+        });
     }
 
     setVariables(tenant: Tenant, variables: any): Promise<TenantVariable> {
-        return this.client.doUpdate(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, variables);
+        return this.client.doUpdate(`${spaceScopedRoutePrefix}/tenants/${tenant.Id}/variables`, variables, {
+            spaceName: this.spaceName,
+            id: tenant.Id,
+        });
     }
 
     missingVariables(filterOptions: FilterOptions = {}, includeDetails: boolean = false): Promise<TenantMissingVariable[]> {
         const payload = {
+            spaceName: this.spaceName,
             environmentId: filterOptions.environmentId,
             includeDetails: includeDetails,
             projectId: filterOptions.projectId,

--- a/src/features/tenants/tenantRepository.ts
+++ b/src/features/tenants/tenantRepository.ts
@@ -24,7 +24,7 @@ export class TenantRepository extends SpaceScopedBasicRepository<Tenant, NewTena
     }
 
     getVariables(tenant: Tenant): Promise<TenantVariable> {
-        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`);
+        return this.client.request(`${spaceScopedRoutePrefix}/tenants/{id}/variables`, tenant);
     }
 
     setVariables(tenant: Tenant, variables: any): Promise<TenantVariable> {


### PR DESCRIPTION
The API requests in the Tenant Repository were missing `spaceName` and other parameters.

fixes: https://github.com/OctopusDeploy/api-client.ts/issues/156

Also fixes the same problem with `setVariables`, `missingVariables` and `tagTest`

[sc-41544]