### PR TITLE
feat: Adds access token authentication to client

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -50,7 +50,8 @@ const configuration: ClientConfiguration = {
 Each parameter serve a specific purpose:
 
 * `agent` (optional) defines an HTTP proxy agent that may be defined for debugging purposes (i.e. Fiddler) -- useful for viewing inbound/outbound messages between the API client and the target instance of Octopus Deploy
-* `apiKey` (required) defines the API key to be used to connect to Octopus Deploy (see [How to Create an API Key](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for more information concerning API keys)
+* `apiKey` (optional) defines the API key to be used to connect to Octopus Deploy (see [How to Create an API Key](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for more information concerning API keys). One of `apiKey` or `accessToken` is required.
+* `accessToken` (optional) defines the access token to be used to connect to Octopus Deploy. Access tokens can be obtained using OpenID Connect identities. One of `accessToken` or `apiKey` is required.
 * `instanceURL` (required) defines the full URL of target instance of Octopus Deploy (i.e. `'https://demo.octopus.app'`)
 * `autoConnect` (optional) informs the `Client` to automatically attempt to connect to the target instance of Octopus Deploy when `Client.create(configuration)` is invoked
 * `space`: (optional) defines the target space in Octopus Deploy for API operations -- assumes the default space if undefined

--- a/src/adapters/axiosAdapter.ts
+++ b/src/adapters/axiosAdapter.ts
@@ -3,23 +3,11 @@ import axios from "axios";
 import type { Adapter, AdapterResponse } from "../adapter";
 import { AdapterError } from "../adapter";
 import { ClientOptions } from "../clientOptions";
+import { createRequestHeaders } from "./createRequestHeaders";
 
 export class AxiosAdapter<TResource> implements Adapter<TResource> {
     public async execute(options: ClientOptions): Promise<AdapterResponse<TResource>> {
         try {
-            const headers: RawAxiosRequestHeaders = {
-                "Accept-Encoding": "gzip,deflate,compress", // HACK: required for https://github.com/axios/axios/issues/5346 -- this line can be removed once this bug has been fixed
-            };
-            if (options.configuration.apiKey) {
-                headers["X-Octopus-ApiKey"] = options.configuration.apiKey;
-            }
-            if (options.configuration.accessToken) {
-                headers["Authorization"] = `Bearer ${options.configuration.accessToken}`;
-            }
-            if (!options.configuration.accessToken && !options.configuration.apiKey) {
-                // Backward compatibility: Add the api key header in with a blank value
-                headers["X-Octopus-ApiKey"] = "";
-            }
             const config: AxiosRequestConfig = {
                 httpsAgent: options.configuration.httpsAgent,
                 url: options.url,
@@ -28,7 +16,7 @@ export class AxiosAdapter<TResource> implements Adapter<TResource> {
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 method: options.method as Method,
                 data: options.requestBody,
-                headers: headers,
+                headers: createRequestHeaders(options.configuration),
                 responseType: "json",
             };
             if (typeof XMLHttpRequest === "undefined") {

--- a/src/adapters/axiosAdapter.ts
+++ b/src/adapters/axiosAdapter.ts
@@ -16,6 +16,10 @@ export class AxiosAdapter<TResource> implements Adapter<TResource> {
             if (options.configuration.accessToken) {
                 headers["Authorization"] = `Bearer ${options.configuration.accessToken}`;
             }
+            if (!options.configuration.accessToken && !options.configuration.apiKey) {
+                // Backward compatibility: Add the api key header in with a blank value
+                headers["X-Octopus-ApiKey"] = "";
+            }
             const config: AxiosRequestConfig = {
                 httpsAgent: options.configuration.httpsAgent,
                 url: options.url,

--- a/src/adapters/createRequestHeaders.test.ts
+++ b/src/adapters/createRequestHeaders.test.ts
@@ -1,0 +1,48 @@
+import { ClientConfiguration } from "../clientConfiguration";
+import { createRequestHeaders } from "./createRequestHeaders";
+
+describe("createRequestHeaders", () => {
+    test("when api key is provided it is put into the correct request header", () => {
+        const configuration: ClientConfiguration = {
+            instanceURL: "https://my.octopus.app",
+            userAgentApp: "createRequestHeader-tests",
+            apiKey: "api-key",
+        };
+
+        const headers = createRequestHeaders(configuration);
+
+        expect(headers).toEqual({
+            "Accept-Encoding": "gzip,deflate,compress",
+            "X-Octopus-ApiKey": "api-key",
+        });
+    });
+
+    test("when an access token is provided it is put into the correct request header", () => {
+        const configuration: ClientConfiguration = {
+            instanceURL: "https://my.octopus.app",
+            userAgentApp: "createRequestHeader-tests",
+            accessToken: "access-token",
+        };
+
+        const headers = createRequestHeaders(configuration);
+
+        expect(headers).toEqual({
+            "Accept-Encoding": "gzip,deflate,compress",
+            Authorization: "Bearer access-token",
+        });
+    });
+
+    test("when neither an access token or api key is provided then the correct api key header is filled in for backward compatibility", () => {
+        const configuration: ClientConfiguration = {
+            instanceURL: "https://my.octopus.app",
+            userAgentApp: "createRequestHeader-tests",
+        };
+
+        const headers = createRequestHeaders(configuration);
+
+        expect(headers).toEqual({
+            "Accept-Encoding": "gzip,deflate,compress",
+            "X-Octopus-ApiKey": "",
+        });
+    });
+});

--- a/src/adapters/createRequestHeaders.ts
+++ b/src/adapters/createRequestHeaders.ts
@@ -1,0 +1,20 @@
+import type { RawAxiosRequestHeaders } from "axios";
+import { ClientConfiguration } from "../clientConfiguration";
+
+export function createRequestHeaders(configuration: ClientConfiguration): RawAxiosRequestHeaders {
+    const headers: RawAxiosRequestHeaders = {
+        "Accept-Encoding": "gzip,deflate,compress", // HACK: required for https://github.com/axios/axios/issues/5346 -- this line can be removed once this bug has been fixed
+    };
+    if (configuration.apiKey) {
+        headers["X-Octopus-ApiKey"] = configuration.apiKey;
+    }
+    if (configuration.accessToken) {
+        headers["Authorization"] = `Bearer ${configuration.accessToken}`;
+    }
+    if (!configuration.accessToken && !configuration.apiKey) {
+        // Backward compatibility: Add the api key header in with a blank value
+        headers["X-Octopus-ApiKey"] = "";
+    }
+
+    return headers;
+}

--- a/src/clientConfiguration.ts
+++ b/src/clientConfiguration.ts
@@ -4,7 +4,8 @@ import { Logger } from "./logger";
 export interface ClientConfiguration {
     userAgentApp: string;
     httpsAgent?: Agent;
-    apiKey: string;
+    apiKey?: string;
+    accessToken?: string;
     instanceURL: string;
     logging?: Logger;
 }


### PR DESCRIPTION
This PR adds support for authenticating to the Octopus API using an access token as a bearer token in the `Authorization` header, as part of supporting OIDC for connecting to the API.

The `apiKey` property in the `ClientConfiguration` type has been made optional, and backward compatibility has been preserved in the handling of headers, such that if none are provided then `X-Octopus-ApiKey` will be passed with an empty string.

Note: The intent is to treat this as a minor version bump as the changes are backward compatible.