### PR TITLE
Handle Unicode characters in zips

### DIFF
--- a/src/features/packages/pack/zipUtils.ts
+++ b/src/features/packages/pack/zipUtils.ts
@@ -53,8 +53,12 @@ export async function doZip(
     setCompressionLevel(zip, compressionLevel || 8);
 
     process.chdir(initialWorkingDirectory);
+    if (fs.existsSync(archivePath) && overwrite === false)
+    {
+        return;
+    }
 
-    await zip.writeZipPromise(archivePath, { overwrite: overwrite || true });
+    return zip.writeZip(archivePath, () => {});
 }
 
 const setCompressionLevel = (zip: AdmZip, level: number): void => {

--- a/src/features/packages/pack/zipUtils.ts
+++ b/src/features/packages/pack/zipUtils.ts
@@ -55,7 +55,7 @@ export async function doZip(
     process.chdir(initialWorkingDirectory);
     if (fs.existsSync(archivePath) && overwrite === false)
     {
-        logger.info?.(`Found an existing archive at ${archivePath} and overwrite is disabled. The existing archive will not be over-written.`);
+        logger.info?.(`Found an existing archive at ${archivePath} and overwrite is disabled. The existing archive will not be overwritten.`);
         return;
     }
 

--- a/src/features/packages/pack/zipUtils.ts
+++ b/src/features/packages/pack/zipUtils.ts
@@ -55,6 +55,7 @@ export async function doZip(
     process.chdir(initialWorkingDirectory);
     if (fs.existsSync(archivePath) && overwrite === false)
     {
+        logger.info?.(`Found an existing archive at ${archivePath} and overwrite is disabled. The existing archive will not be over-written.`);
         return;
     }
 


### PR DESCRIPTION
Adm-Zip has an [issue handling unicode characters](https://github.com/cthackers/adm-zip/issues/255). Interestingly this is only the case on the `zip.writeZipPromise` method and not the sync version `zip.writeZip`. This change moves to the sync version of the method call.

Fixes https://github.com/OctopusDeploy/api-client.ts/issues/173
Fixes https://github.com/OctopusDeploy/api-client.ts/issues/175