### PR TITLE
(fix): Checking request has parameter before reading them

### DIFF
--- a/src/spaceScopedRequest.ts
+++ b/src/spaceScopedRequest.ts
@@ -4,5 +4,5 @@ export interface SpaceScopedRequest {
 }
 
 export function isSpaceScopedRequest(command: any): command is SpaceScopedRequest {
-    return "spaceName" in command;
+    return command && "spaceName" in command;
 }


### PR DESCRIPTION
Hi,

The _list_ method of [basicRepository](https://github.com/OctopusDeploy/api-client.ts/blob/main/src/features/basicRepository.ts#L51) allows us not passing any parameter/argument for our request.

But the _Client_, before performing the request, will [check](https://github.com/OctopusDeploy/api-client.ts/blob/main/src/client.ts#L192) is the request is _scape scoped_ by reading its parameters, using the [_isSpaceScopedRequest_ method of _SpaceScopedRequest_](https://github.com/OctopusDeploy/api-client.ts/blob/main/src/spaceScopedRequest.ts#L7).

This method doesn't check that the parameters are not empty (= command is defined) before trying to access them; which result in a runtime error : 
```
/xxx/node_modules/@octopusdeploy/api-client/dist/spaceScopedRequest.js:5
    return "spaceName" in command;
                       ^
TypeError: Cannot use 'in' operator to search for 'spaceName' in undefined
    at isSpaceScopedRequest (/xxx/node_modules/@octopusdeploy/api-client/dist/spaceScopedRequest.js:5:24)
    at Client.<anonymous> (/xxx/node_modules/@octopusdeploy/api-client/dist/client.js:240:76)
```

I encountered the issue while calling _list_ without parameters on a _SpaceRepository_ instance ; while trying to retrieve Spaces without any criterion.

The fix proposal is to check that the request do have parameters before accessing them; avoiding a runtime error when there isn't any parameter.
