### PR TITLE
Fix an issue where the timeout passed in is not adhered to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 reports
 *.tgz
 .idea
+.env

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
             moduleDirectories: ["<rootDir>/src/", "node_modules"],
             moduleFileExtensions: ["ts", "js"],
             resetMocks: true,
+            setupFiles: ['dotenv/config'],
             setupFilesAfterEnv: ["jest-expect-message", "jest-extended"],
             testRegex: ".*\\.(test|spec)\\.(ts)$",
             transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/urijs": "^1.19.19",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
+        "dotenv": "^16.4.5",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -2511,6 +2512,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8730,6 +8743,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.4.284",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/urijs": "^1.19.19",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
+    "dotenv": "^16.4.5",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/src/features/packages/packageRepository.test.ts
+++ b/src/features/packages/packageRepository.test.ts
@@ -82,7 +82,7 @@ describe("push package", () => {
         } catch (error) {
             expect(error).toBeDefined();
             if (error instanceof Error) {
-                expect(error.message).toContain(`A package with the same ID and version already exists`);
+                expect(error.message).toContain(`A package with the same name and version already exists`);
             } else {
                 throw error;
             }

--- a/src/features/serverTasks/serverTaskWaiter.test.ts
+++ b/src/features/serverTasks/serverTaskWaiter.test.ts
@@ -1,23 +1,204 @@
+/* eslint-disable @typescript-eslint/init-declarations */
+import { randomUUID } from "crypto";
+import {
+    DeploymentEnvironment,
+    Project,
+    UserProjection,
+    userGetCurrent,
+    SpaceRepository,
+    ProjectGroupRepository,
+    LifecycleRepository,
+    ProjectRepository,
+    NewProject,
+    DeploymentProcessRepository,
+    RunCondition,
+    PackageRequirement,
+    StartTrigger,
+    RunConditionForAction,
+    EnvironmentRepository,
+    CreateReleaseCommandV1,
+    ReleaseRepository,
+    CreateDeploymentUntenantedCommandV1,
+    DeploymentRepository,
+} from "../..";
 import { Client } from "../../client";
 import { processConfiguration } from "../../clientConfiguration.test";
-import { ServerTaskDetails } from "./serverTaskDetails";
+import { Space } from "../spaces";
+import { ServerTask } from "./serverTask";
 import { ServerTaskWaiter } from "./serverTaskWaiter";
 
-describe("push build information", () => {
+describe("wait for server task", () => {
     jest.setTimeout(100000);
 
-    test("wait for non-existent task exits correctly", async () => {
-        const client = await Client.create(processConfiguration());
-        const serverTaskWaiter = new ServerTaskWaiter(client, "Default");
+    describe("non-existent task", () => {
+        test("wait exits correctly", async () => {
+            const client = await Client.create(processConfiguration());
+            const serverTaskWaiter = new ServerTaskWaiter(client, "Default");
 
-        const startTime = new Date();
+            const startTime = new Date();
 
-        await expect(() => {
-            return serverTaskWaiter.waitForServerTaskToComplete("ServerTasks-99999", 1000, 10000);
-        }).rejects.toThrow("Unknown task Id(s) ServerTasks-99999");
+            await expect(() => {
+                return serverTaskWaiter.waitForServerTaskToComplete("ServerTasks-99999", 1000, 10000);
+            }).rejects.toThrow("Unknown task Id(s) ServerTasks-99999");
 
-        const endTime = new Date();
-        const timeDiff = endTime.getTime() - startTime.getTime();
-        expect(timeDiff).toBeLessThan(6000);
+            const endTime = new Date();
+            const timeDiff = endTime.getTime() - startTime.getTime();
+            expect(timeDiff).toBeLessThan(6000);
+        });
+    });
+
+    describe("existing task", () => {
+        let client: Client;
+        let environment: DeploymentEnvironment;
+        let project: Project;
+        let space: Space;
+        let user: UserProjection;
+
+        jest.setTimeout(100000);
+
+        beforeAll(async () => {
+            client = await Client.create(processConfiguration());
+            console.log(`Client connected to API endpoint successfully.`);
+            user = await userGetCurrent(client);
+        });
+
+        beforeEach(async () => {
+            const spaceName = randomUUID().substring(0, 20);
+            console.log(`Creating space, "${spaceName}"...`);
+            const spaceRepository = new SpaceRepository(client);
+            space = await spaceRepository.create({ Name: spaceName, SpaceManagersTeams: [], SpaceManagersTeamMembers: [user.Id], IsDefault: false });
+            console.log(`Space "${spaceName}" created successfully.`);
+
+            const projectGroup = (await new ProjectGroupRepository(client, spaceName).list({ take: 1 })).Items[0];
+            const lifecycle = (await new LifecycleRepository(client, spaceName).list({ take: 1 })).Items[0];
+
+            const projectName = randomUUID();
+            console.log(`Creating project, "${projectName}"...`);
+            project = await new ProjectRepository(client, spaceName).create(NewProject(projectName, projectGroup, lifecycle));
+            console.log(`Project "${projectName}" created successfully.`);
+
+            const deploymentProcessRepository = new DeploymentProcessRepository(client, space.Name);
+            const deploymentProcess = await deploymentProcessRepository.get(project);
+            deploymentProcess.Steps = [
+                {
+                    Condition: RunCondition.Success,
+                    PackageRequirement: PackageRequirement.LetOctopusDecide,
+                    StartTrigger: StartTrigger.StartAfterPrevious,
+                    Id: "",
+                    Name: randomUUID(),
+                    Properties: {},
+                    Actions: [
+                        {
+                            Id: "",
+                            Name: "Run a Script",
+                            ActionType: "Octopus.Script",
+                            Notes: null,
+                            IsDisabled: false,
+                            CanBeUsedForProjectVersioning: false,
+                            IsRequired: false,
+                            WorkerPoolId: null,
+                            Container: {
+                                Image: null,
+                                FeedId: null,
+                            },
+                            WorkerPoolVariable: "",
+                            Environments: [],
+                            ExcludedEnvironments: [],
+                            Channels: [],
+                            TenantTags: [],
+                            Packages: [],
+                            Condition: RunConditionForAction.Success,
+                            Properties: {
+                                "Octopus.Action.RunOnServer": "true",
+                                "Octopus.Action.Script.ScriptSource": "Inline",
+                                "Octopus.Action.Script.Syntax": "PowerShell",
+                                "Octopus.Action.Script.ScriptBody": "Write-Host 'hello'; Start-Sleep -Seconds 10",
+                            },
+                        },
+                    ],
+                },
+            ];
+
+            console.log(`Updating deployment process, "${deploymentProcess.Id}"...`);
+            await deploymentProcessRepository.update(project, deploymentProcess);
+            console.log(`Deployment process, "${deploymentProcess.Id}" updated successfully.`);
+
+            const environmentName = randomUUID();
+            console.log(`Creating environment, "${environmentName}"...`);
+            const envRepository = new EnvironmentRepository(client, spaceName);
+            environment = await envRepository.create({ Name: environmentName });
+            console.log(`Environment "${environment.Name}" created successfully.`);
+        });
+
+        test("deploy with default timeout exits correctly", async () => {
+            const releaseCommand: CreateReleaseCommandV1 = {
+                spaceName: space.Name,
+                ProjectName: project.Name,
+            };
+            const releaseRepository = new ReleaseRepository(client, space.Name);
+            const releaseResponse = await releaseRepository.create(releaseCommand);
+
+            const deployCommand: CreateDeploymentUntenantedCommandV1 = {
+                spaceName: space.Name,
+                ProjectName: project.Name,
+                ReleaseVersion: releaseResponse.ReleaseVersion,
+                EnvironmentNames: [environment.Name],
+            };
+            const deploymentRepository = new DeploymentRepository(client, space.Name);
+            const response = await deploymentRepository.create(deployCommand);
+            const deployments = await deploymentRepository.list({ ids: response.DeploymentServerTasks.map((t) => t.DeploymentId) });
+            expect(deployments.Items.length).toBe(1);
+
+            const taskIds = response.DeploymentServerTasks.map((x) => x.ServerTaskId);
+            const e = new ServerTaskWaiter(client, space.Name);
+
+            const completedTasks = await e.waitForServerTasksToComplete(taskIds, 1000, 600000, (serverTask: ServerTask): void => {
+                console.log(`Waiting for task ${serverTask.Id}. Current status: ${serverTask.State}`);
+            });
+            expect(completedTasks.length).toBe(1);
+        });
+
+        test("deploy with short timeout exits correctly", async () => {
+            const releaseCommand: CreateReleaseCommandV1 = {
+                spaceName: space.Name,
+                ProjectName: project.Name,
+            };
+            const releaseRepository = new ReleaseRepository(client, space.Name);
+            const releaseResponse = await releaseRepository.create(releaseCommand);
+
+            const deployCommand: CreateDeploymentUntenantedCommandV1 = {
+                spaceName: space.Name,
+                ProjectName: project.Name,
+                ReleaseVersion: releaseResponse.ReleaseVersion,
+                EnvironmentNames: [environment.Name],
+            };
+            const deploymentRepository = new DeploymentRepository(client, space.Name);
+            const response = await deploymentRepository.create(deployCommand);
+            const deployments = await deploymentRepository.list({ ids: response.DeploymentServerTasks.map((t) => t.DeploymentId) });
+            expect(deployments.Items.length).toBe(1);
+
+            const taskIds = response.DeploymentServerTasks.map((x) => x.ServerTaskId);
+            const e = new ServerTaskWaiter(client, space.Name);
+
+            const completedTasks = await e.waitForServerTasksToComplete(taskIds, 1000, 5000, (serverTask: ServerTask): void => {
+                console.log(`Waiting for task ${serverTask.Id}. Current status: ${serverTask.State}`);
+            });
+            expect(completedTasks.length).toBe(0);
+
+            await e.waitForServerTasksToComplete(taskIds, 1000, 600000, (serverTask: ServerTask): void => {
+                console.log(`Waiting for task ${serverTask.Id}. Current status: ${serverTask.State}`);
+            });
+        });
+
+        afterEach(async () => {
+            if (space === undefined || space === null) return;
+
+            console.log(`Deleting space, ${space.Name}...`);
+            space.TaskQueueStopped = true;
+            const spaceRepository = new SpaceRepository(client);
+            await spaceRepository.modify(space);
+            await spaceRepository.del(space);
+            console.log(`Space '${space.Name}' deleted successfully.`);
+        });
     });
 });

--- a/src/features/serverTasks/serverTaskWaiter.ts
+++ b/src/features/serverTasks/serverTaskWaiter.ts
@@ -50,8 +50,8 @@ export class ServerTaskWaiter {
 
         const completedTasks: ServerTask[] = [];
 
-        while (!stop) {
-            try {
+        try {
+            while (!stop) {
                 const tasks = await spaceServerTaskRepository.getByIds(serverTaskIds);
 
                 const unknownTaskIds = serverTaskIds.filter((id) => tasks.filter((t) => t.Id === id).length == 0);
@@ -79,13 +79,15 @@ export class ServerTaskWaiter {
                 // once all tasks have completed we can stop the loop
                 if (serverTaskIds.length === 0 || tasks.length === 0) {
                     stop = true;
+                    clearTimeout(t);
                 }
-            } finally {
-                clearTimeout(t);
-            }
 
-            await sleep(statusCheckSleepCycle);
+                await sleep(statusCheckSleepCycle);
+            }
+        } finally {
+            clearTimeout(t);
         }
+
         return completedTasks;
     }
 }


### PR DESCRIPTION
Due to the `try/finally` block is inside the `while` the timeout is immediately cleared and we don't exit the `while` loop as `stop` is only set to `true` if the task(s) being awaited are completed.

Fixes OctopusDeploy/api-client.ts#178

[sc-82468]