### PR TITLE
Adds AllowIgnoreChannelRules to project

### DIFF
--- a/src/features/projects/project.ts
+++ b/src/features/projects/project.ts
@@ -74,7 +74,7 @@ export interface Project extends SpaceScopedResource, NamedResource {
     ProjectGroupId: string;
     Description: string;
     IsDisabled: boolean;
-    AllowIgnoreChannelRules: boolean;
+    AllowIgnoreChannelRules?: boolean;
 }
 
 export type ProjectOrSummary = Project | ProjectSummary;

--- a/src/features/projects/project.ts
+++ b/src/features/projects/project.ts
@@ -74,6 +74,7 @@ export interface Project extends SpaceScopedResource, NamedResource {
     ProjectGroupId: string;
     Description: string;
     IsDisabled: boolean;
+    AllowIgnoreChannelRules: boolean;
 }
 
 export type ProjectOrSummary = Project | ProjectSummary;


### PR DESCRIPTION
This PR adds the `AllowIgnoreChannelRules` property to the project type for the upcoming Git protection rules feature.

Note that this client currently doesn't support channels so I haven't added anything for other properties in that type for this feature.

[sc-83092]