### PR TITLE
Add build information push error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           SA_PASSWORD: ${{ env.SA_PASSWORD }}
           MSSQL_PID: Developer
         options: >-
-          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" -N -C || exit 1"
           --health-interval 10s
           --health-timeout 3s
           --health-retries 10

--- a/src/features/buildInformation/buildInformationRepository.test.ts
+++ b/src/features/buildInformation/buildInformationRepository.test.ts
@@ -73,6 +73,37 @@ describe("push build information", () => {
         expect(result.PackageVersionBuildInformation?.VcsCommitNumber).toStrictEqual("314cf2c3ee916c92a384c2796a6abe332d678e4f");
     });
 
+    test("to a package failed", async () => {
+        const packageRepository = new PackageRepository(client, space.Name);
+        await packageRepository.push([path.join(tempOutDir, "Hello.1.0.0.zip")]);
+
+        const buildInformation = {
+            spaceName: space.Name,
+            BuildEnvironment: "BitBucket",
+            Branch: "main",
+            BuildNumber: "288",
+            BuildUrl: "https://bitbucket.org/octopussamples/petclinic/addon/pipelines/home#!/results/288",
+            VcsType: "Git",
+            VcsRoot: "http://bitbucket.org/octopussamples/petclinic",
+            VcsCommitNumber: "314cf2c3ee916c92a384c2796a6abe332d678e4f",
+            Packages: [{ Id: "Hello", Version: "1.0.0" }],
+            Commits: [
+                {
+                    Id: "314cf2c3ee916c92a384c2796a6abe332d678e4f",
+                    Comment: "GOD-1 - 'test build info",
+                },
+            ],
+        };
+
+        expect.assertions(1);
+        try {
+            await new BuildInformationRepository(client, space.Name).push(buildInformation);
+            await new BuildInformationRepository(client, space.Name).push(buildInformation);
+        } catch (error) {
+            expect(error).toBeDefined();
+        }
+    });
+
     afterAll(async () => {
         await rm(tempOutDir, { recursive: true });
     });

--- a/src/features/buildInformation/buildInformationRepository.test.ts
+++ b/src/features/buildInformation/buildInformationRepository.test.ts
@@ -95,12 +95,17 @@ describe("push build information", () => {
             ],
         };
 
-        expect.assertions(1);
+        expect.assertions(2);
         try {
             await new BuildInformationRepository(client, space.Name).push(buildInformation);
             await new BuildInformationRepository(client, space.Name).push(buildInformation);
         } catch (error) {
             expect(error).toBeDefined();
+            if (error instanceof Error) {
+                expect(error.message).toContain(`Metadata for the specified Package ID and version already exists.`);
+            } else {
+                throw error;
+            }
         }
     });
 

--- a/src/features/buildInformation/buildInformationRepository.ts
+++ b/src/features/buildInformation/buildInformationRepository.ts
@@ -57,6 +57,27 @@ export class BuildInformationRepository {
             );
         }
 
-        await Promise.allSettled(tasks);
+        const rejectedTasks: unknown[] = [];
+
+        const completedTasks = await Promise.allSettled(tasks);
+        for (const t of completedTasks) {
+            if (t.status === "rejected") {
+                rejectedTasks.push(t.reason);
+            }
+        }
+
+        const errors: Error[] = [];
+        for (const e of rejectedTasks) {
+            if (e instanceof Error) {
+                errors.push(e);
+            } else {
+                errors.push(new Error(`unexpected error: ${e}`));
+            }
+        }
+
+        if (errors.length > 0) {
+            const error = errors.map((e) => `${e}`);
+            throw new Error(error.join("\n"));
+        }
     }
 }


### PR DESCRIPTION
There was no error in the build logs when a user was trying to push build info from ADO to Octopus which failed as they did not have the correct permissions.

This PR includes code to throw an error when the build information push fails.

The following error will be thrown when the user does not have the correct permissions:
```
Error: You do not have permission to perform this action. Please contact your Octopus administrator. Missing permission: BuildInformationPush
```