### PR TITLE
fix: Make runbookretention unit optional

### DIFF
--- a/src/features/projects/runbooks/runbookRetentionPeriod.ts
+++ b/src/features/projects/runbooks/runbookRetentionPeriod.ts
@@ -3,7 +3,7 @@ import { RetentionUnit } from "../../..";
 export interface RunbookRetentionPeriod {
     QuantityToKeep: number;
     ShouldKeepForever: boolean;
-    Unit: RunbookRetentionUnit;
+    Unit?: RunbookRetentionUnit;
 }
 
 export enum RunbookRetentionUnit {


### PR DESCRIPTION
# Summary
We recently added the Unit property to the RunbookRetentionPeriod object. In doing so, we made it a required field. In reality, the field is optional and will default to "items" if it is not provided. This preserved previously functionality.