### PR TITLE
Support for overriding a deployment freeze 

### DIFF
--- a/src/features/projects/createExecutionBaseV1.ts
+++ b/src/features/projects/createExecutionBaseV1.ts
@@ -10,6 +10,8 @@ export interface CreateExecutionBaseV1 extends SpaceScopedOperation {
     RunAt?: Date | undefined;
     NoRunAfter?: Date | undefined;
     Variables?: PromptedVariableValues;
+    DeploymentFreezeOverrideReason?: string;
+    DeploymentFreezeNames?: string[];
 }
 
 export interface PromptedVariableValues {


### PR DESCRIPTION
Update CreateExecutionBaseV1 to support override deployment freeze
-  DeploymentFreezeOverrideReason
-  DeploymentFreezeNames

[Fixes-96959](https://app.shortcut.com/octopusdeploy/story/96959/add-support-for-overriding-a-deployment-freeze-in-the-cli)