### PR TITLE
feat: Add live status dashboard option to Project

### DIFF
--- a/src/features/projects/project.ts
+++ b/src/features/projects/project.ts
@@ -75,6 +75,7 @@ export interface Project extends SpaceScopedResource, NamedResource {
     Description: string;
     IsDisabled: boolean;
     AllowIgnoreChannelRules?: boolean;
+    CombineHealthAndSyncStatusInDashboardLiveStatus?: boolean;
 }
 
 export type ProjectOrSummary = Project | ProjectSummary;


### PR DESCRIPTION
In https://github.com/OctopusDeploy/OctopusDeploy/pull/33075 we added a new project setting to alter the behaviour of how [Kubernetes Live Object Status](https://octopus.com/docs/kubernetes/live-object-status) is displayed on dashboards.

This change adds the field to this client.