### PR TITLE
feat: Add ability to cancel tasks on timeout in server task waiter

### DIFF
--- a/src/features/serverTasks/index.ts
+++ b/src/features/serverTasks/index.ts
@@ -1,5 +1,6 @@
 export * from "./serverTask";
 export * from "./serverTaskDetails";
+export * from "./serverTaskRepository";
 export * from "./serverTaskWaiter";
 export * from "./spaceServerTaskRepository";
 export * from "./taskState";

--- a/src/features/serverTasks/serverTaskRepository.ts
+++ b/src/features/serverTasks/serverTaskRepository.ts
@@ -1,0 +1,19 @@
+import { Client } from "../../client";
+import { apiLocation } from "../../apiLocation";
+
+export class ServerTaskRepository {
+    private baseApiPathTemplate = `${apiLocation}/tasks`;
+    private readonly client: Client;
+
+    constructor(client: Client) {
+        this.client = client;
+    }
+
+    async cancel(serverTaskId: string): Promise<void> {
+        if (!serverTaskId) {
+            throw new Error("Server Task Id was not provided");
+        }
+        
+        await this.client.post<void>(`${this.baseApiPathTemplate}/${serverTaskId}/cancel`, {});
+    }
+}


### PR DESCRIPTION
Adds the ability to cancel tasks on timeout and throw an error in the server task waiter.

This will be used in ADO and GHA to cancel tasks and show a failure on these steps when `cancelOnTimeout` is set to true.

[sc-114678]