### PR TITLE
ci: Update publish to perform OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,20 +17,19 @@ jobs:
         with:
           release-type: node
           token: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
+          
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          cache: 'npm'
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@octopusdeploy'
-        if: ${{ steps.release.outputs.release_created }}
+          package-manager-cache: false  # never use caching in release builds
+        if: ${{ steps.release.outputs.release_created }}        
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.INTEGRATIONS_NPM_ACCESS_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Following instructions from https://docs.npmjs.com/trusted-publishers

Have set up this repo as a trusted publisher in npm