### PR TITLE
Add GitResources to CreateReleaseCommandV1

### DIFF
--- a/src/features/projects/releases/createReleaseCommandV1.test.ts
+++ b/src/features/projects/releases/createReleaseCommandV1.test.ts
@@ -1,0 +1,30 @@
+import type { Client } from "../../../client";
+import { CreateReleaseCommandV1 } from "./createReleaseCommandV1";
+import { ReleaseRepository } from "./releaseRepository";
+
+describe("CreateReleaseCommandV1", () => {
+    test("create posts GitResources in the create/v1 request body", async () => {
+        const doCreate = jest.fn().mockResolvedValue({ ReleaseId: "Releases-1", ReleaseVersion: "1.0.0" });
+        // A minimal stand-in for Client exercising only the members create() touches.
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const client = {
+            getServerInformation: jest.fn().mockResolvedValue({ version: "2022.4.0" }),
+            debug: jest.fn(),
+            error: jest.fn(),
+            doCreate,
+        } as unknown as Client;
+
+        const command: CreateReleaseCommandV1 = {
+            spaceName: "Spaces-1",
+            ProjectName: "My Project",
+            GitResources: ["Update Argo Manifests:refs/heads/feature-x"],
+        };
+
+        await new ReleaseRepository(client, "Default").create(command);
+
+        expect(doCreate).toHaveBeenCalledTimes(1);
+        const [path, body] = doCreate.mock.calls[0];
+        expect(path).toContain("/releases/create/v1");
+        expect(body.GitResources).toEqual(["Update Argo Manifests:refs/heads/feature-x"]);
+    });
+});

--- a/src/features/projects/releases/createReleaseCommandV1.ts
+++ b/src/features/projects/releases/createReleaseCommandV1.ts
@@ -8,6 +8,7 @@ export interface CreateReleaseCommandV1 extends SpaceScopedOperation {
     ReleaseVersion?: string;
     ChannelName?: string;
     Packages?: string[];
+    GitResources?: string[];
     ReleaseNotes?: string;
     IgnoreIfAlreadyExists?: boolean;
     IgnoreChannelRules?: boolean;


### PR DESCRIPTION
### Background

The Octopus release-create (v1) API already accepts a `gitResources` field (an array of `StepName:GitRef` / `StepName:GitResourceName:GitRef` entries) that binds the Git reference used for a step's Git resource **at release-creation time**. The Octopus CLI exposes this via `--git-resource`, and the Go SDK via `CreateReleaseCommandV1.GitResources`.

The TypeScript `CreateReleaseCommandV1` interface was missing this field, so consumers (notably the [create-release GitHub Action](https://github.com/OctopusDeploy/create-release-action)) had no way to set it.

### Change

Adds an optional `GitResources?: string[]` to `CreateReleaseCommandV1`. `ReleaseRepository.create()` already spreads the whole command into the POST body, so no other change is required for it to reach the server.

### Why

Enables the create-release GitHub Action to target a specific Git branch/ref for steps such as **Update Argo CD Application Manifests** on version-controlled/Argo projects — e.g. deploying a feature branch to Dev from GitHub Actions (customer request **SF-2251**). Companion PR: `OctopusDeploy/create-release-action`.

### Tests

Adds a unit test asserting `GitResources` is included in the `/releases/create/v1` request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
